### PR TITLE
ci(smoke-tests): install agent-browser runtime

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -45,6 +45,17 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Add node_modules/.bin to PATH
+              run: echo "$PWD/node_modules/.bin" >> $GITHUB_PATH
+
+            - name: Install browser dependencies
+              run: agent-browser install --with-deps
+
+            - name: Warm up browser
+              run: |
+                  agent-browser open about:blank
+                  agent-browser close
+
             - name: Restore Turborepo cache
               id: cache-turborepo-restore
               uses: actions/cache/restore@v5


### PR DESCRIPTION
## Summary
- add node_modules/.bin to PATH in the smoke test workflow
- install Chromium and Linux browser dependencies for agent-browser
- warm the browser before Claude runs smoke tests

## Why
The smoke test skill uses agent-browser, but the workflow did not provision the Playwright/Chromium runtime required to launch a browser in GitHub Actions.
