### PR TITLE
fix: UX/UI polish — cursor, font size, layout, edit action

### DIFF
--- a/.claude/skills/plantz-adlc-code/references/tailwind-postcss.md
+++ b/.claude/skills/plantz-adlc-code/references/tailwind-postcss.md
@@ -21,12 +21,15 @@ For Rslib (library) configs, import `RslibConfigTransformer` from `@workleap/rsl
 
 ## Cross-package class scanning
 
-Consuming apps use `@source` directives in their CSS to tell Tailwind where to find utility classes used in `@packages/components`:
+The `@import "tailwindcss"` directive lives inside `packages/components/src/styles/globals.css`. Consuming apps import it transitively via `@import "@packages/components/globals.css"` — they must **not** add a separate `@import "tailwindcss"` line.
+
+Consuming apps also use `@source` directives to tell Tailwind where to find utility classes in workspace packages:
 
 ```css
-@import "tailwindcss";
 @import "@packages/components/globals.css";
+
 @source "../../../../packages/components/src/**/*.{ts,tsx}";
+@source "../../../../packages/plants-core/src/**/*.{ts,tsx}";
 ```
 
-If you add new source directories under `packages/components/src/`, add a corresponding `@source` directive in consuming apps.
+If you add a new workspace package whose components are rendered in the host app, add a corresponding `@source` directive in `apps/host/src/styles/globals.css`. Domain-module source paths (e.g., `management/plants`, `today/landing-page`) also need their own `@source` entries there.

--- a/.claude/skills/plantz-adlc-plan/references/tailwind-postcss.md
+++ b/.claude/skills/plantz-adlc-plan/references/tailwind-postcss.md
@@ -19,12 +19,15 @@ For Rslib (library) configs, import `RslibConfigTransformer` from `@workleap/rsl
 
 ## Cross-package class scanning
 
-Consuming apps use `@source` directives in their CSS to tell Tailwind where to find utility classes used in `@packages/components`:
+The `@import "tailwindcss"` directive lives inside `packages/components/src/styles/globals.css`. Consuming apps import it transitively via `@import "@packages/components/globals.css"` — they must **not** add a separate `@import "tailwindcss"` line.
+
+Consuming apps also use `@source` directives to tell Tailwind where to find utility classes in workspace packages:
 
 ```css
-@import "tailwindcss";
 @import "@packages/components/globals.css";
+
 @source "../../../../packages/components/src/**/*.{ts,tsx}";
+@source "../../../../packages/plants-core/src/**/*.{ts,tsx}";
 ```
 
-If you add new source directories under `packages/components/src/`, add a corresponding `@source` directive in consuming apps.
+If you add a new workspace package whose components are rendered in the host app, add a corresponding `@source` directive in `apps/host/src/styles/globals.css`. Domain-module source paths (e.g., `management/plants`, `today/landing-page`) also need their own `@source` entries there.

--- a/.claude/skills/plantz-adlc-test/references/tailwind-postcss.md
+++ b/.claude/skills/plantz-adlc-test/references/tailwind-postcss.md
@@ -21,12 +21,15 @@ For Rslib (library) configs, import `RslibConfigTransformer` from `@workleap/rsl
 
 ## Cross-package class scanning
 
-Consuming apps use `@source` directives in their CSS to tell Tailwind where to find utility classes used in `@packages/components`:
+The `@import "tailwindcss"` directive lives inside `packages/components/src/styles/globals.css`. Consuming apps import it transitively via `@import "@packages/components/globals.css"` — they must **not** add a separate `@import "tailwindcss"` line.
+
+Consuming apps also use `@source` directives to tell Tailwind where to find utility classes in workspace packages:
 
 ```css
-@import "tailwindcss";
 @import "@packages/components/globals.css";
+
 @source "../../../../packages/components/src/**/*.{ts,tsx}";
+@source "../../../../packages/plants-core/src/**/*.{ts,tsx}";
 ```
 
-If you add new source directories under `packages/components/src/`, add a corresponding `@source` directive in consuming apps.
+If you add a new workspace package whose components are rendered in the host app, add a corresponding `@source` directive in `apps/host/src/styles/globals.css`. Domain-module source paths (e.g., `management/plants`, `today/landing-page`) also need their own `@source` entries there.

--- a/apps/host/src/styles/globals.css
+++ b/apps/host/src/styles/globals.css
@@ -1,4 +1,3 @@
-@import "tailwindcss";
 @import "@packages/components/globals.css";
 
 @source "../../../../packages/components/src/**/*.{ts,tsx}";

--- a/apps/today/landing-page/src/LandingPage.tsx
+++ b/apps/today/landing-page/src/LandingPage.tsx
@@ -91,7 +91,7 @@ export function LandingPage() {
                             };
                             return (
                                 <div key={plant.id} role="listitem" style={rowStyle}>
-                                    <PlantListItem plant={plant} onEdit={handleViewDetail} />
+                                    <PlantListItem plant={plant} onClick={handleViewDetail} />
                                 </div>
                             );
                         })}

--- a/packages/components/src/components/ui/checkbox.tsx
+++ b/packages/components/src/components/ui/checkbox.tsx
@@ -8,7 +8,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         <CheckboxPrimitive.Root
             data-slot="checkbox"
             className={cn(
-                "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+                "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
                 className,
             )}
             {...props}

--- a/packages/components/src/components/ui/switch.tsx
+++ b/packages/components/src/components/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({
             data-slot="switch"
             data-size={size}
             className={cn(
-                "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+                "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-50",
                 className,
             )}
             {...props}

--- a/packages/components/src/styles/globals.css
+++ b/packages/components/src/styles/globals.css
@@ -45,7 +45,25 @@
     --radius-xl: calc(var(--radius) + 4px);
 }
 
+/* Restore cursor: pointer for interactive elements (Tailwind v4 removed it). */
+a,
+button,
+label,
+select,
+summary,
+[role="button"],
+[role="checkbox"],
+[role="switch"],
+[type="button"],
+[type="reset"],
+[type="submit"],
+[type="checkbox"],
+[type="radio"] {
+    cursor: pointer;
+}
+
 :root {
+    font-size: 18px;
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);

--- a/packages/plants-core/src/PlantListItem.stories.tsx
+++ b/packages/plants-core/src/PlantListItem.stories.tsx
@@ -140,3 +140,14 @@ export const NoSelectionNoDelete: Story = {
         selected: undefined,
     },
 };
+
+export const ClickOnly: Story = {
+    args: {
+        plant: makePlant(),
+        onClick: () => {},
+        onToggleSelect: undefined,
+        onEdit: undefined,
+        onDelete: undefined,
+        selected: undefined,
+    },
+};

--- a/packages/plants-core/src/PlantListItem.tsx
+++ b/packages/plants-core/src/PlantListItem.tsx
@@ -1,5 +1,5 @@
 import { Droplets, Pencil, Trash2 } from "lucide-react";
-import { memo, useCallback } from "react";
+import { memo, useCallback, type MouseEvent } from "react";
 
 import { Button, Checkbox } from "@packages/components";
 
@@ -7,40 +7,65 @@ import { locations, wateringTypes } from "./constants.ts";
 import type { Plant } from "./plantSchema.ts";
 import { getOptionLabel, isDueForWatering } from "./plantUtils.ts";
 
+function stopPropagation(e: MouseEvent) {
+    e.stopPropagation();
+}
+
 interface PlantListItemProps {
     plant: Plant;
     selected?: boolean | undefined;
+    onClick?: ((plant: Plant) => void) | undefined;
     onToggleSelect?: ((id: string) => void) | undefined;
     onEdit?: ((plant: Plant) => void) | undefined;
     onDelete?: ((plant: Plant) => void) | undefined;
 }
 
-export const PlantListItem = memo(function PlantListItem({ plant, selected = false, onToggleSelect, onEdit, onDelete }: PlantListItemProps) {
+export const PlantListItem = memo(function PlantListItem({ plant, selected = false, onClick, onToggleSelect, onEdit, onDelete }: PlantListItemProps) {
     const due = isDueForWatering(plant);
 
+    const isClickable = !!(onClick || onEdit);
+
     const handleToggleSelect = useCallback(() => onToggleSelect?.(plant.id), [onToggleSelect, plant.id]);
-    const handleEdit = useCallback(() => onEdit?.(plant), [onEdit, plant]);
-    const handleDelete = useCallback(() => onDelete?.(plant), [onDelete, plant]);
+    const handleClick = useCallback(() => (onClick ?? onEdit)?.(plant), [onClick, onEdit, plant]);
+    const handleEdit = useCallback(
+        (e: MouseEvent) => {
+            e.stopPropagation();
+            onEdit?.(plant);
+        },
+        [onEdit, plant],
+    );
+    const handleDelete = useCallback(
+        (e: MouseEvent) => {
+            e.stopPropagation();
+            onDelete?.(plant);
+        },
+        [onDelete, plant],
+    );
 
     return (
-        <div className={`border-border flex h-full items-center gap-3 border-b px-4 py-2.5 transition-colors ${due ? "bg-destructive/5" : "hover:bg-muted/50"}`}>
-            {onToggleSelect && <Checkbox checked={selected} onCheckedChange={handleToggleSelect} aria-label={`Select ${plant.name}`} />}
-            <div
-                className={`flex min-w-0 flex-1 items-center gap-4 ${onEdit ? "cursor-pointer" : ""}`}
-                role={onEdit ? "button" : undefined}
-                tabIndex={onEdit ? 0 : undefined}
-                onClick={onEdit ? handleEdit : undefined}
-                onKeyDown={
-                    onEdit
-                        ? (e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                  e.preventDefault();
-                                  handleEdit();
-                              }
+        <div
+            className={`border-border flex h-full items-center gap-3 border-b px-4 py-2.5 transition-colors ${due ? "bg-destructive/5" : "hover:bg-muted/50"}`}
+            role={isClickable ? "button" : undefined}
+            tabIndex={isClickable ? 0 : undefined}
+            onClick={isClickable ? handleClick : undefined}
+            onKeyDown={
+                isClickable
+                    ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              handleClick();
                           }
-                        : undefined
-                }
-            >
+                      }
+                    : undefined
+            }
+        >
+            {onToggleSelect && (
+                // oxlint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- stopPropagation prevents row click; checkbox handles its own keyboard events
+                <span onClick={stopPropagation}>
+                    <Checkbox checked={selected} onCheckedChange={handleToggleSelect} aria-label={`Select ${plant.name}`} />
+                </span>
+            )}
+            <div className="flex min-w-0 flex-1 items-center gap-4">
                 <div className="flex min-w-0 flex-1 flex-col md:flex-row md:items-center md:gap-4">
                     <div className="flex items-center gap-2">
                         <span className="truncate text-sm font-medium">{plant.name}</span>


### PR DESCRIPTION
## Summary

- **Fix filter bar padding & list item layout**: Removed duplicate `@import "tailwindcss"` from host app's `globals.css`. The components `globals.css` already imports Tailwind, so the host was loading it twice, causing CSS cascade/specificity issues with all Tailwind utilities.
- **Increase base font size**: Added `font-size: 18px` to `:root` in `packages/components/src/styles/globals.css` so all rem-based sizes scale up for improved readability.
- **Restore cursor:pointer on interactive elements**: Added a global CSS rule targeting `a`, `button`, `label`, `select`, `summary`, and ARIA role elements to restore `cursor: pointer` (removed by default in Tailwind v4). Also added `cursor-pointer` directly to `Switch` and `Checkbox` component classes.
- **Remove edit action from Today's list**: Added an `onClick` prop to `PlantListItem` and switched Today's `LandingPage` from `onEdit` to `onClick`, so clicking a row opens the detail dialog without showing a misleading pencil icon.
- **Update skill reference docs**: Updated all three `tailwind-postcss.md` files to document the single-import pattern (no duplicate `@import "tailwindcss"`).

## Test plan

- [ ] `pnpm dev-host` — verify filter bar has padding, list items render horizontally on desktop, all interactive elements show pointer cursor, text is larger
- [ ] Today's page — list items have no pencil/delete icons; clicking a row opens PlantDetailDialog
- [ ] Management page — pencil and delete icons still appear and function as before
- [ ] `pnpm dev-today-storybook` / `pnpm dev-management-storybook` — verify visual parity with the app
- [ ] PlantListItem ClickOnly story renders correctly in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)