### PR TITLE
feat: rework lists to use the browser's native scrollbar for improved scrolling experience

### DIFF
--- a/apps/management/plants/src/PlantsPage.tsx
+++ b/apps/management/plants/src/PlantsPage.tsx
@@ -1,5 +1,5 @@
 import { useLiveQuery } from "@tanstack/react-db";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { Plus } from "lucide-react";
 import { useState, useRef, useMemo, useCallback } from "react";
 
@@ -12,9 +12,6 @@ import { EditPlantDialog } from "./EditPlantDialog.tsx";
 import { useManagementPlantsCollection } from "./ManagementPlantsContext.tsx";
 import { createManagementPlantActions } from "./plantsCollection.ts";
 
-const scrollbarGutterStyle = { scrollbarGutter: "stable" as const };
-const scrollContainerStyle = { height: "calc(100vh - 376px)", ...scrollbarGutterStyle };
-
 export function PlantsPage() {
     const { filters, updateFilter, clearFilters, hasActiveFilters } = usePlantFilters();
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -22,7 +19,7 @@ export function PlantsPage() {
     const [editPlant, setEditPlant] = useState<Plant | null>(null);
     const [editOpen, setEditOpen] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<Plant[] | null>(null);
-    const parentRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
 
     const collection = useManagementPlantsCollection();
     const actions = useMemo(() => createManagementPlantActions(collection), [collection]);
@@ -35,11 +32,11 @@ export function PlantsPage() {
         return applyPlantFilters(sorted, filters);
     }, [allPlants, filters]);
 
-    const virtualizer = useVirtualizer({
+    const virtualizer = useWindowVirtualizer({
         count: plants.length,
-        getScrollElement: () => parentRef.current,
         estimateSize: () => 49,
         overscan: 10,
+        scrollMargin: (listRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY,
     });
 
     const allSelected = plants.length > 0 && plants.every((p) => selectedIds.has(p.id));
@@ -129,14 +126,14 @@ export function PlantsPage() {
 
     if (!isReady) {
         return (
-            <div className="flex h-full items-center justify-center p-6">
+            <div className="flex items-center justify-center p-6">
                 <p className="text-muted-foreground text-sm">Loading plants...</p>
             </div>
         );
     }
 
     return (
-        <div className="flex h-full flex-col gap-4 p-6">
+        <div className="flex flex-col gap-4 p-6">
             <div className="flex items-center justify-between">
                 <h1 className="text-xl font-semibold">Plants</h1>
                 <div className="flex items-center gap-2">
@@ -162,30 +159,26 @@ export function PlantsPage() {
                 {plants.length} plant{plants.length !== 1 ? "s" : ""}
             </div>
 
-            <div className="border-border flex-1 overflow-hidden rounded-lg border">
-                <div className="bg-muted/50 overflow-y-auto [&>div]:bg-transparent" style={scrollbarGutterStyle}>
-                    <PlantListHeader showActions selectAllChecked={allSelected} onToggleSelectAll={toggleAll} />
-                </div>
-                <div ref={parentRef} className="overflow-auto" style={scrollContainerStyle}>
-                    <div role="list" aria-label="Plants" style={virtualizerContainerStyle}>
-                        {virtualizer.getVirtualItems().map((virtualRow) => {
-                            const plant = plants[virtualRow.index]!;
-                            // oxlint-disable-next-line react-perf/jsx-no-new-object-as-prop -- Virtual row positioning requires per-item inline styles
-                            const rowStyle = {
-                                position: "absolute" as const,
-                                top: 0,
-                                left: 0,
-                                width: "100%",
-                                height: `${virtualRow.size}px`,
-                                transform: `translateY(${virtualRow.start}px)`,
-                            };
-                            return (
-                                <div key={plant.id} role="listitem" style={rowStyle}>
-                                    <PlantListItem plant={plant} selected={selectedIds.has(plant.id)} onToggleSelect={toggleSelect} onEdit={handleEditPlant} onDelete={handleDeleteSingle} />
-                                </div>
-                            );
-                        })}
-                    </div>
+            <div className="border-border rounded-lg border">
+                <PlantListHeader showActions selectAllChecked={allSelected} onToggleSelectAll={toggleAll} />
+                <div ref={listRef} role="list" aria-label="Plants" style={virtualizerContainerStyle}>
+                    {virtualizer.getVirtualItems().map((virtualRow) => {
+                        const plant = plants[virtualRow.index]!;
+                        // oxlint-disable-next-line react-perf/jsx-no-new-object-as-prop -- Virtual row positioning requires per-item inline styles
+                        const rowStyle = {
+                            position: "absolute" as const,
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            height: `${virtualRow.size}px`,
+                            transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+                        };
+                        return (
+                            <div key={plant.id} role="listitem" style={rowStyle}>
+                                <PlantListItem plant={plant} selected={selectedIds.has(plant.id)} onToggleSelect={toggleSelect} onEdit={handleEditPlant} onDelete={handleDeleteSingle} />
+                            </div>
+                        );
+                    })}
                 </div>
             </div>
 

--- a/apps/today/landing-page/src/LandingPage.tsx
+++ b/apps/today/landing-page/src/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useLiveQuery } from "@tanstack/react-db";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useState, useRef, useMemo, useCallback } from "react";
 
 import { applyPlantFilters, FilterBar, isDueForWatering, PlantListHeader, PlantListItem, usePlantFilters } from "@packages/plants-core";
@@ -8,13 +8,10 @@ import type { Plant } from "@packages/plants-core";
 import { PlantDetailDialog } from "./PlantDetailDialog.tsx";
 import { useTodayPlantsCollection } from "./TodayPlantsContext.tsx";
 
-const scrollbarGutterStyle = { scrollbarGutter: "stable" as const };
-const scrollContainerStyle = { height: "calc(100vh - 376px)", ...scrollbarGutterStyle };
-
 export function LandingPage() {
     const { filters, updateFilter, clearFilters, hasActiveFilters } = usePlantFilters();
     const [detailPlant, setDetailPlant] = useState<Plant | null>(null);
-    const parentRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
 
     const collection = useTodayPlantsCollection();
     const { data: allPlants, isReady } = useLiveQuery((q) => q.from({ plant: collection }));
@@ -29,11 +26,11 @@ export function LandingPage() {
         return applyPlantFilters(duePlants, filters);
     }, [allPlants, filters]);
 
-    const virtualizer = useVirtualizer({
+    const virtualizer = useWindowVirtualizer({
         count: plants.length,
-        getScrollElement: () => parentRef.current,
         estimateSize: () => 49,
         overscan: 10,
+        scrollMargin: (listRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY,
     });
 
     const handleViewDetail = useCallback((plant: Plant) => {
@@ -58,14 +55,14 @@ export function LandingPage() {
 
     if (!isReady) {
         return (
-            <div className="flex h-full items-center justify-center p-6">
+            <div className="flex items-center justify-center p-6">
                 <p className="text-muted-foreground text-sm">Loading plants...</p>
             </div>
         );
     }
 
     return (
-        <div className="flex h-full flex-col gap-4 p-6">
+        <div className="flex flex-col gap-4 p-6">
             <div className="flex items-center justify-between">
                 <h1 className="text-xl font-semibold">Today</h1>
             </div>
@@ -76,30 +73,26 @@ export function LandingPage() {
                 {plants.length} plant{plants.length !== 1 ? "s" : ""} due for watering
             </div>
 
-            <div className="border-border flex-1 overflow-hidden rounded-lg border">
-                <div className="bg-muted/50 overflow-y-auto [&>div]:bg-transparent" style={scrollbarGutterStyle}>
-                    <PlantListHeader />
-                </div>
-                <div ref={parentRef} className="overflow-auto" style={scrollContainerStyle}>
-                    <div role="list" aria-label="Plants due for watering" style={virtualizerContainerStyle}>
-                        {virtualizer.getVirtualItems().map((virtualRow) => {
-                            const plant = plants[virtualRow.index]!;
-                            // oxlint-disable-next-line react-perf/jsx-no-new-object-as-prop -- Virtual row positioning requires per-item inline styles
-                            const rowStyle = {
-                                position: "absolute" as const,
-                                top: 0,
-                                left: 0,
-                                width: "100%",
-                                height: `${virtualRow.size}px`,
-                                transform: `translateY(${virtualRow.start}px)`,
-                            };
-                            return (
-                                <div key={plant.id} role="listitem" style={rowStyle}>
-                                    <PlantListItem plant={plant} onClick={handleViewDetail} />
-                                </div>
-                            );
-                        })}
-                    </div>
+            <div className="border-border rounded-lg border">
+                <PlantListHeader />
+                <div ref={listRef} role="list" aria-label="Plants due for watering" style={virtualizerContainerStyle}>
+                    {virtualizer.getVirtualItems().map((virtualRow) => {
+                        const plant = plants[virtualRow.index]!;
+                        // oxlint-disable-next-line react-perf/jsx-no-new-object-as-prop -- Virtual row positioning requires per-item inline styles
+                        const rowStyle = {
+                            position: "absolute" as const,
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            height: `${virtualRow.size}px`,
+                            transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+                        };
+                        return (
+                            <div key={plant.id} role="listitem" style={rowStyle}>
+                                <PlantListItem plant={plant} onClick={handleViewDetail} />
+                            </div>
+                        );
+                    })}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Replaced `useVirtualizer` with `useWindowVirtualizer` in both Management PlantsPage and Today LandingPage so the browser's native window scrollbar controls scrolling instead of per-list fixed-height scroll containers
- Removed fixed-height scroll containers (`scrollContainerStyle`, `scrollbarGutterStyle`, `parentRef`) and `h-full` constraints so pages grow with content in normal document flow
- Added dynamic `scrollMargin` measurement via `getBoundingClientRect().top + window.scrollY` for correct document-relative positioning

## Quality checks

- [x] Lint
- [x] Module validation
- [x] Accessibility
- [x] Visual/interactive verification
- [x] Storybook a11y

## Verified acceptance criteria

- ✅ `[static]` PlantsPage.tsx imports and uses `useWindowVirtualizer` (not `useVirtualizer`) and has no `getScrollElement` call
- ✅ `[static]` LandingPage.tsx imports and uses `useWindowVirtualizer` (not `useVirtualizer`) and has no `getScrollElement` call
- ✅ `[static]` Neither page file contains `scrollContainerStyle`, `scrollbarGutterStyle`, or a hardcoded height value
- ✅ `[static]` No TypeScript type errors after the change
- ✅ `[visual]` Management PlantsPage: header, filters, status line, and plant list all render in normal document flow with no inner scrollbar visible
- ✅ `[visual]` Management PlantsPage: list header row and body rows are aligned
- ✅ `[visual]` Today LandingPage: header, filters, status line, and plant list all render in normal document flow with no inner scrollbar visible
- ✅ `[visual]` Today LandingPage: list header row and body rows are aligned
- ✅ `[visual]` Management PlantsPage: bordered card wrapper around the list area is still visible
- ✅ `[visual]` Today LandingPage: bordered card wrapper around the list area is still visible
- ✅ `[visual]` With enough plants to exceed the viewport, the browser's native window scrollbar appears
- ✅ `[interactive]` Management PlantsPage: scrolling via browser window scrollbar reveals additional plant rows
- ✅ `[interactive]` Today LandingPage: scrolling via browser window scrollbar reveals additional plant rows
- ✅ `[interactive]` Management PlantsPage: clicking a plant row's edit button still opens the edit dialog
- ✅ `[interactive]` Today LandingPage: clicking a plant row still opens the detail dialog
- ✅ `[interactive]` Management PlantsPage: when the selection bar appears/disappears, the list continues to render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)