### PR TITLE
chore: add ADLC patch/revise flows, migrate artifacts to .adlc/, stremline skills

### DIFF
--- a/.claude/skills/plantz-adlc-code/SKILL.md
+++ b/.claude/skills/plantz-adlc-code/SKILL.md
@@ -16,7 +16,7 @@ Implement the plan or fix issues reported by the test phase or CI.
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `run-uuid`         | Run folder identifier                                                                                                                                   |
 | `iteration`        | Current iteration number (starts at 1). This is the iteration the agent will **write** to (`changes-[iteration].md`).                                   |
-| Plan path          | Always provided — `./tmp/runs/[run-uuid]/plan.md`                                                                                                       |
+| Plan path          | Always provided — `.adlc/[run-uuid]/plan.md`                                                                                                       |
 | Issues path        | `null` on iteration 1. On fix cycles: the path to the issues file — either `test-issues-*.md` (from test phase) or `ci-issues-*.md` (from CI failures). |
 | Changes path       | `null` on iteration 1. On fix cycles: the explicit path to the **previous** iteration's changes file (e.g., `changes-1.md` when `iteration=2`).         |
 | Escalation context | `null` unless the orchestrator rejected a previous escalation. If provided: path to the rejected escalation file from a prior iteration.                |
@@ -30,13 +30,13 @@ This skill runs in one of two modes, determined by the inputs:
 
 ## Procedure
 
-1. Read `agent-docs/ARCHITECTURE.md`, `agent-docs/adr/index.md`, `agent-docs/odr/index.md`, and these reference files: `agent-docs/references/domains.md`, `agent-docs/references/msw-tanstack-query.md`, `agent-docs/references/storybook.md`, `agent-docs/references/tailwind-postcss.md`, `agent-docs/references/shadcn.md`, `agent-docs/references/color-mode.md`, `agent-docs/references/bundle-size-budget.md`.
+1. Read `agent-docs/ARCHITECTURE.md`, `agent-docs/adr/index.md`, `agent-docs/odr/index.md`, and these reference files: `agent-docs/references/domains.md`, `agent-docs/references/msw-tanstack-query.md`, `agent-docs/references/storybook.md`, `agent-docs/references/tailwind-postcss.md`, `agent-docs/references/shadcn.md`, `agent-docs/references/color-mode.md`, `agent-docs/references/bundle-size-budget.md`, `agent-docs/references/static-analysis.md`, `agent-docs/references/turborepo.md`, `agent-docs/references/typescript.md`.
 2. Load the `accessibility`, `shadcn`, `frontend-design`, `workleap-react-best-practices`, `workleap-squide`, `workleap-web-configs`, and `pnpm` skills for implementation guidance.
 3. Read the plan file for architectural context. In **fix mode**, also read the issues file and previous changes file to understand what was done and what failed. If an escalation context path is provided, read it to understand what was tried and why the orchestrator disagreed.
 4. **Fix mode only — assess before coding.** Read every issue in the issues file and attempt all fixes. For any fix where the plan's approach seems fundamentally mismatched — the plan assumed a component decomposition or data flow that doesn't work, a library choice is fighting the framework, or the fix requires cross-module access the plan didn't anticipate — explain the specific concern in `changes-[iteration].md` under **Notes** (what about the plan is wrong, not just "this is hard"). Fix the issue anyway to the best of your ability. **Only Subagent B writes escalation files** — A never escalates directly.
 5. **Plan mode only:** If the plan requires scaffolding a new module, load and use the `plantz-scaffold-domain-module` skill. If it requires a new Storybook, use `plantz-scaffold-domain-storybook`.
 6. **Start the dev server or Storybook before implementing.** Run the appropriate root script for the affected package — `pnpm dev-host` for app routes, or the matching `pnpm dev-{domain}-storybook` for stories (e.g., `pnpm dev-today-storybook`). Use Chrome DevTools MCP tools to see what you're building as you go. Implement the changes with the browser open — navigate to relevant pages, take screenshots to check your work, and course-correct as you code. Follow all technology rules from the `agent-docs/references/` files read in step 1.
-7. Write a summary of all changes to `./tmp/runs/[run-uuid]/changes-[iteration].md`. **Plan mode only:** before writing, review your implementation for any choice where a reasonable reviewer might pick differently — state placement, component boundaries, data flow, patterns that look wrong but are intentional, alternatives you tried and rejected. Document these in the **Decisions & Trade-offs** section. Zero entries is fine if the implementation was straightforward; aim for 2-5 when there are genuine trade-offs. Fix iterations skip this section.
+7. Write a summary of all changes to `.adlc/[run-uuid]/changes-[iteration].md`. **Plan mode only:** before writing, review your implementation for any choice where a reasonable reviewer might pick differently — state placement, component boundaries, data flow, patterns that look wrong but are intentional, alternatives you tried and rejected. Document these in the **Decisions & Trade-offs** section. Zero entries is fine if the implementation was straightforward; aim for 2-5 when there are genuine trade-offs. Fix iterations skip this section.
 
 ## Changes File Format
 
@@ -132,7 +132,7 @@ B has five responsibilities, in order:
 
     **Escalation threshold:** Escalate only when the plan's approach is fundamentally wrong and no amount of code editing can fix it. Examples: the plan decomposed components in a way that makes the required data flow impossible; the plan chose a library that conflicts with the framework; the plan assumed module boundaries that force a cross-module import. Do NOT escalate for: difficulty, missing details the code agent can infer, suboptimal but workable approaches, or issues that the test phase will catch.
 
-    If B identifies a structural issue meeting this threshold, B writes `./tmp/runs/[run-uuid]/escalation-[iteration].md` using this format:
+    If B identifies a structural issue meeting this threshold, B writes `.adlc/[run-uuid]/escalation-[iteration].md` using this format:
 
     ```markdown
     # Escalation — Iteration [N]

--- a/.claude/skills/plantz-adlc-document/SKILL.md
+++ b/.claude/skills/plantz-adlc-document/SKILL.md
@@ -16,11 +16,11 @@ Audit agent documentation for drift after implementation and fix any issues foun
 | ----------- | ------------------------------------------------------------------------------ |
 | `run-uuid`  | Run folder identifier                                                          |
 | `iteration` | The latest iteration number (used to know how many `changes-*.md` files exist) |
-| Plan path   | `./tmp/runs/[run-uuid]/plan.md` — needed for the `## Decisions` section        |
+| Plan path   | `.adlc/[run-uuid]/plan.md` — needed for the `## Decisions` section        |
 
 ## Procedure
 
-1. Read all `./tmp/runs/[run-uuid]/changes-*.md` files to understand the full scope of changes.
+1. Read all `.adlc/[run-uuid]/changes-*.md` files to understand the full scope of changes.
 2. Read the plan file's `## Decisions` section. Each entry describes a choice where alternatives existed — use these to determine whether new ADRs or ODRs are needed.
 3. Read `agent-docs/ARCHITECTURE.md`, `agent-docs/adr/index.md`, `agent-docs/odr/index.md`, and any `agent-docs/references/` files whose topics overlap with the changes (e.g., `msw-tanstack-query.md` if data layer changed, `storybook.md` if story conventions changed, `tailwind-postcss.md` if styling changed, `bundle-size-budget.md` if budgets changed, `ci-cd.md` if workflows changed, `color-mode.md` if theming changed, `shadcn.md` if components changed, `domains.md` if module boundaries changed).
 4. Load the `plantz-audit-agent-docs` skill and run the audit. This detects drift between agent-docs and the actual codebase.

--- a/.claude/skills/plantz-adlc-orchestrator/SKILL.md
+++ b/.claude/skills/plantz-adlc-orchestrator/SKILL.md
@@ -15,15 +15,22 @@ Coordinates the full Agent Development Life Cycle for a feature by spawning spec
 1. **Subagent A** (drafter): produces the initial output (plan, code, test report, doc update).
 2. **Subagent B** (challenger): reviews Subagent A's output and improves it. B fixes everything it can by editing the output files and the code directly. The one exception: B can write an escalation file for structural issues that require a plan revision (see "Escalation Check").
 
-The **orchestrator** spawns both subagents directly — subagents never spawn further subagents. Only one subagent writes to the repo or output file at a time (A finishes before B starts).
+The **orchestrator** spawns both subagents directly — subagents never spawn further subagents.
 
 The real validation gate is the `plantz-adlc-test` phase — B improves quality before that gate but is not the final check.
 
-**Subagent lifecycle:** Claude Code subagents are stateless. Each spawned subagent starts fresh. Context is passed between iterations via files in `./tmp/runs/[run-uuid]/`. Always spawn new subagents with the relevant file paths — never refer to "existing subagents."
+Context is passed between subagents via files in `.adlc/[run-uuid]/`. Always spawn new subagents with the relevant file paths.
 
 ## Hard Constraints
 
-- **Never edit repository files directly** — only `./tmp/runs/` and git/shell commands. All source code, config, docs, and tests go through subagents. The orchestrator's context window is too scarce to spend on code. If a change seems "too small to delegate," delegate it anyway.
+- **Never edit repository files directly** — only `.adlc/` and git/shell commands. All source code, config, docs, and tests go through subagents. The orchestrator's context window is too scarce to spend on code. If a change seems "too small to delegate," delegate it anyway.
+
+## Inputs (optional — for revise mode)
+
+| Input                | Description                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--revise`           | The user's change request (feedback text). Presence of this input indicates revise mode — skip `.adlc/` cleanup, use current branch |
+| `--previous-run-uuid`| UUID of the previous run. Required when `--revise` is set. Used to locate `.adlc/[uuid]/plan.md`                    |
 
 ## Port Cleanup Between Subagents
 
@@ -34,57 +41,50 @@ The real validation gate is the `plantz-adlc-test` phase — B improves quality 
 If a subagent fails to produce its expected output file, or if a command fails unexpectedly:
 
 1. **Stop the run** — do not retry blindly.
-2. **Preserve artifacts** — do not clean up `./tmp/runs/[run-uuid]/`. All intermediate files (`changes-*.md`, `test-issues-*.md`, `orchestrator-state.md`) remain on disk for post-mortem.
-3. **Write a failure summary** to `./tmp/runs/[run-uuid]/failure-summary.md` containing: the step that failed, the error or unresolved issues, and what was attempted.
-
-Only clean up the run folder on successful completion (step 9).
+2. **Write a failure summary** to `.adlc/[run-uuid]/failure-summary.md` containing: the step that failed, the error or unresolved issues, and what was attempted.
 
 ## Steps
 
 ### Step 1 — Generate run UUID and create run folder
 
-Generate a UUID and create `./tmp/runs/[run-uuid]/`. Pass the UUID to every subagent. Each run gets its own folder to avoid file collisions. (`tmp/` is already in `.gitignore`.)
+**New feature (default):** Delete any existing `.adlc/` directory (handle both tracked and untracked files). Generate a UUID and create `.adlc/[run-uuid]/`. Pass the UUID to every subagent.
 
-### Step 2 — Create a branch from `main`
+**Revise mode (when `--revise` is provided):** Do NOT delete `.adlc/`. Generate a new UUID and create `.adlc/[run-uuid]/`.
 
-First, run `git status --short` to verify the working tree is clean. If there are uncommitted changes, stop and ask the user to resolve them.
+### Step 2 — Create a branch from `main` (or checkout existing)
 
-Branch format: `{type}/{short-description}` (kebab-case).
-Use the commit type matching the feature intent: `feat`, `fix`, `chore`, `docs`, `refactor`.
-Example: `feat/add-watering-schedules`.
+**New feature (default):** Verify the working tree is clean. If there are uncommitted changes, stop and ask the user to resolve them. Pull latest `main` and create a branch. Branch format: `{type}/{short-description}` (kebab-case). Use the commit type matching the feature intent: `feat`, `fix`, `chore`, `docs`, `refactor`. Example: `feat/add-watering-schedules`.
 
-Pull latest `main` and create the branch.
+**Revise mode (when `--revise` is provided):** Skip branch creation. Use the current branch. Pull latest. Discover the PR number from the branch.
 
 ### Step 3 — Plan
 
-**If an inline plan was provided in the prompt:** Write it to `./tmp/runs/[run-uuid]/plan.md`. Spawn only **Subagent B** with `mode=review`, `run-uuid`, feature description, and the plan path.
+**Revise mode (when `--revise` is provided):** Spawn two subagents using the `plantz-adlc-plan` skill with `mode=revision`, `run-uuid`, feature description (the `--revise` text), the previous plan path (`.adlc/[--previous-run-uuid value]/plan.md`), and escalation path `null`.
 
-**Otherwise:** Spawn two subagents with `mode=draft`, `run-uuid`, feature description. Existing plan path and escalation path are `null`.
+**New feature (default):** Spawn two subagents using the `plantz-adlc-plan` skill with `mode=draft`, `run-uuid`, feature description. Existing plan path and escalation path are `null`.
 
-When done, verify `./tmp/runs/[run-uuid]/plan.md` exists. If not, fail the run.
+When done, verify `.adlc/[run-uuid]/plan.md` exists. If not, fail the run.
 
 ### Step 4 — Code
 
 Spawn two subagents using the `plantz-adlc-code` skill.
 Pass: `run-uuid`, `iteration=1`, plan path. Issues path, changes path, and escalation context are `null` for iteration 1.
-When done, verify `./tmp/runs/[run-uuid]/changes-1.md` exists. If not, fail the run.
+When done, verify `.adlc/[run-uuid]/changes-1.md` exists. If not, fail the run.
 
-**Escalation check:** After the code subagent returns, check for `./tmp/runs/[run-uuid]/escalation-1.md`. If present, follow the escalation check procedure (see "Escalation check" below).
+**Escalation check:** After the code subagent returns, check for `.adlc/[run-uuid]/escalation-1.md`. If present, follow the escalation check procedure (see "Escalation check" below).
 
 ### Step 5 — Simplify
 
-Spawn **one** subagent with the `simplify` skill to review the uncommitted changes for dead code, redundant abstractions, and over-engineering. This runs once on the initial implementation — fix iterations produce small surgical patches that don't need simplification.
+Spawn **one** subagent with the `simplify` skill. If it crashes or returns no output, log a warning and continue.
 
-If the subagent crashes or returns no output, log a warning and continue.
-
-After the simplify subagent returns, if it made changes, append a `## Simplify` section to `changes-[iteration].md` listing the files it modified and what it removed. This keeps the changes file accurate for downstream phases (test, document, merge).
+If it made changes, append a `## Simplify` section to `changes-[iteration].md` listing the files it modified. This keeps the changes file accurate for downstream phases.
 
 ### Step 6 — Test and iterate
 
 Spawn two subagents using the `plantz-adlc-test` skill.
-Pass: `run-uuid`, `iteration=1`, plan path (`./tmp/runs/[run-uuid]/plan.md`), previous issues path (`null` for iteration 1).
+Pass: `run-uuid`, `iteration=1`, plan path (`.adlc/[run-uuid]/plan.md`), previous issues path (`null` for iteration 1).
 
-- If `./tmp/runs/[run-uuid]/test-issues-[test iteration].md` is produced with issues:
+- If `.adlc/[run-uuid]/test-issues-[test iteration].md` is produced with issues:
     - Check `Test iteration` in `orchestrator-state.md` — if ≥ 5, follow the failure handling procedure (maximum 5 test iterations).
     - Increment `Test iteration`. Update `orchestrator-state.md` with the new value and set `Current step: 6-code`.
     - Spawn new `plantz-adlc-code` subagents. Pass: `run-uuid`, `iteration` = `Test iteration`, plan path, the previous iteration's issues file path (`test-issues-[test iteration - 1].md`), the previous iteration's changes file path (`changes-[test iteration - 1].md`), and escalation context (the rejected escalation file path if one was rejected earlier, otherwise `null`). They produce `changes-[test iteration].md`.
@@ -98,21 +98,23 @@ Pass: `run-uuid`, `iteration=1`, plan path (`./tmp/runs/[run-uuid]/plan.md`), pr
 ### Step 7 — Document
 
 Spawn two subagents using the `plantz-adlc-document` skill (following the subagent protocol).
-Pass: `run-uuid`, the final `Test iteration` number, plan path (`./tmp/runs/[run-uuid]/plan.md`).
+Pass: `run-uuid`, the final `Test iteration` number, plan path (`.adlc/[run-uuid]/plan.md`).
 
-When done, run `git diff --stat` to verify the subagent made documentation changes. A documentation phase that changes nothing is unusual — review the subagent's output to confirm it completed normally. If it appears to have crashed, follow the failure handling procedure.
+When done, verify the subagent made documentation changes. A documentation phase that changes nothing is unusual — if it appears to have crashed, follow the failure handling procedure.
 
-### Step 8 — Merge
+### Step 8 — PR
 
-Spawn **one** subagent using the `plantz-adlc-merge` skill. This step uses a single subagent only — concurrent git operations would conflict.
-Pass: `run-uuid`, the branch name from step 2, the commit type from step 2, the plan path (`./tmp/runs/[run-uuid]/plan.md`), the final `Test iteration` number, and `CI iteration` (starts at `0`). Set `CI iteration: 0` in `orchestrator-state.md`.
+Spawn **one** subagent using the `plantz-adlc-pr` skill.
+Pass: `run-uuid`, the branch name from step 2, the commit type from step 2, the plan path (`.adlc/[run-uuid]/plan.md`), the final `Test iteration` number, and `CI iteration` (starts at `0`). Set `CI iteration: 0` in `orchestrator-state.md`.
 
-After the merge subagent creates the PR (or confirms one exists), query the PR number for the branch and record it in `orchestrator-state.md`. This survives context compaction.
+After the PR subagent creates the PR (or confirms one exists), record the PR number in `orchestrator-state.md`.
 
-The merge subagent returns in one of two ways:
+The PR subagent returns in one of two ways:
 
-- **Success:** All CI checks passed and the `run chromatic` label was added to trigger visual regression testing. Chromatic runs asynchronously — the agent does not wait for it. Proceed to Step 9.
-- **CI failure:** The merge subagent writes `ci-issues-[CI iteration].md` and stops.
+- **Success:** All CI checks passed. The run is complete.
+
+**Revise mode:** Pass `--revision` to the PR subagent. The PR subagent appends a `## Revision [N]` section and updates the footer's revise command with the new run UUID.
+- **CI failure:** The PR subagent writes `ci-issues-[CI iteration].md` and stops.
     - Increment `CI iteration`. Update `orchestrator-state.md` with the new value.
     - Check `CI iteration` — if > 3, follow the failure handling procedure (maximum 3 fix attempts).
     - Set `Current step: 8-ci-fix`.
@@ -122,15 +124,11 @@ The merge subagent returns in one of two ways:
     - Spawn new `plantz-adlc-test` subagents. Pass: `run-uuid`, `iteration` = `Test iteration` + `CI iteration`, plan path, previous issues path = `null`.
     - **Completion check:** Verify `changes-[iteration].md` contains `<!-- test-complete -->`. If absent, the test subagent crashed — follow failure handling.
     - If `test-issues-[iteration].md` exists (test failed): treat as a CI failure — return to the top of the CI failure flow above. The test failure consumes one attempt from the shared budget.
-    - If no issues file exists and the marker is present (test passed): spawn a new merge subagent with `Iteration` = `Test iteration` + `CI iteration`, and the current `CI iteration`. On success, proceed to Step 9. On CI failure, return to the top of the CI failure flow above.
-
-### Step 9 — Clean up
-
-Delete the `./tmp/runs/[run-uuid]/` folder.
+    - If no issues file exists and the marker is present (test passed): spawn a new PR subagent with `Iteration` = `Test iteration` + `CI iteration`, and the current `CI iteration`. On success, proceed to Step 9. On CI failure, return to the top of the CI failure flow above.
 
 ## State Persistence
 
-After completing each step, write the current state to `./tmp/runs/[run-uuid]/orchestrator-state.md` atomically (write to a temp file, then rename).
+After completing each step, write the current state to `.adlc/[run-uuid]/orchestrator-state.md`.
 
 Template:
 
@@ -140,7 +138,7 @@ Template:
 - Run UUID: [uuid]
 - Branch: [branch-name]
 - Commit type: [feat/fix/chore/docs/refactor] (conventional commit prefix)
-- Current step: [1-9] (use `6-code` / `6-test` within step 6; `8-ci-fix` / `8-ci-test` within step 8)
+- Current step: [1-8] (use `6-code` / `6-test` within step 6; `8-ci-fix` / `8-ci-test` within step 8)
 - Test iteration: [1-5] (current test-fix cycle — starts at 1, incremented after each test failure)
 - Plan revised: [yes/no]
 - Escalation rejected: [none/iteration-N — brief reason]
@@ -151,25 +149,16 @@ Template:
 
 **Before writing state**, confirm the step's expected artifact exists — do not write state claiming a step completed if its output is missing.
 
-This allows the orchestrator to recover if the context window is compacted mid-run. At the start of each step, read this file to restore state if needed.
-
-## Iteration Tracking
-
-Two iteration counters, both starting at 1:
-
-- **`Test iteration`** (Step 6): Incremented after each test failure. Passed to code and test subagents. Artifacts: `changes-[N].md`, `test-issues-[N].md`. Maximum 5.
-- **`CI iteration`** (Step 8): Starts at 0. Incremented on each failure, then checked before the fix runs. Code and test subagents receive `iteration` = `Test iteration` + `CI iteration` (avoids collisions with Step 6 artifacts). CI issues: `ci-issues-[N].md`. Maximum 3 fix attempts (fail the run when `CI iteration > 3`).
-
 ## Escalation Check
 
-Referenced from Step 4, Step 6, and Step 8. After any code subagent returns, check for `./tmp/runs/[run-uuid]/escalation-[iteration].md`. If absent, continue normally (proceed to the next phase — simplify, test, or CI-test depending on context). If present:
+Referenced from Step 4, Step 6, and Step 8. After any code subagent returns, check for `.adlc/[run-uuid]/escalation-[iteration].md`. If absent, continue normally (proceed to the next phase — simplify, test, or CI-test depending on context). If present:
 
 1. Read `orchestrator-state.md` to check whether `Plan revised` is already `yes`. If so, a plan revision already occurred. Follow the failure handling procedure — but include the second escalation file's diagnosis in `failure-summary.md` so the user understands the additional structural issue that surfaced.
 2. Read the escalation file and judge whether the issue is genuinely structural (the plan's approach is fundamentally wrong) or whether the code agent is being too cautious about a fixable problem.
 3. **If justified:** Spawn `plantz-adlc-plan` subagents with `mode=revision`, feature description, `plan.md` path, and escalation file path. After revision, clean up:
     - Delete all `escalation-*.md`, `changes-*.md`, `test-issues-*.md`, and `ci-issues-*.md` from the run folder.
     - If escalation happened during Step 8: reset the branch to its merge-base with main and force-push.
-    - Reset the working tree to a clean state, preserving the `tmp/` directory.
+    - Reset the working tree to a clean state.
     - Set `Test iteration` to 1, `Plan revised: yes` in state. Restart from Step 4.
-4. **If not justified:** Update `orchestrator-state.md` with `Escalation rejected: iteration-[N] — [one-line reason]`. Proceed to the next phase (simplify, test, or CI-test depending on context). The escalation file remains on disk. Pass it to the next code subagent via the `Escalation context` input if another fix cycle occurs — the code subagent reads it to understand what was tried and why the orchestrator disagreed. If no further fix cycle occurs (tests pass), ignore it.
+4. **If not justified:** Update `orchestrator-state.md` with `Escalation rejected: iteration-[N] — [one-line reason]`. Proceed to the next phase (simplify, test, or CI-test depending on context). Pass the escalation file to the next code subagent via the `Escalation context` input if another fix cycle occurs.
 5. **Maximum 1 plan revision per run.** Enforced by checking `Plan revised` in step 1 above.

--- a/.claude/skills/plantz-adlc-patch/SKILL.md
+++ b/.claude/skills/plantz-adlc-patch/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: plantz-adlc-patch
+description: |
+    Lightweight patch iteration on an existing PR. Applies targeted code fixes, runs tests, and pushes.
+    Triggered by the adlc-patch GitHub Actions workflow when a user comments `/patch <feedback>` on a PR.
+    Use when running in CI as part of the patch workflow. Do NOT use for local development — use the ADLC orchestrator with `--revise` instead.
+license: MIT
+---
+
+# ADLC Patch
+
+Apply targeted fixes to an existing PR based on user feedback.
+
+## Step 1 — Understand
+
+1. Read the feedback carefully.
+2. Read `.adlc/*/plan.md` if one exists for architectural context.
+3. Read the PR diff for context on existing changes.
+4. Read `agent-docs/ARCHITECTURE.md`, `agent-docs/adr/index.md`, `agent-docs/odr/index.md`, and these reference files: `agent-docs/references/domains.md`, `agent-docs/references/msw-tanstack-query.md`, `agent-docs/references/storybook.md`, `agent-docs/references/tailwind-postcss.md`, `agent-docs/references/shadcn.md`, `agent-docs/references/color-mode.md`, `agent-docs/references/bundle-size-budget.md`, `agent-docs/references/static-analysis.md`, `agent-docs/references/turborepo.md`, `agent-docs/references/typescript.md`.
+
+## Step 2 — Apply Changes
+
+1. Load skills as needed for the specific changes (`accessibility`, `shadcn`, `frontend-design`, `workleap-react-best-practices`, `workleap-squide`, `workleap-web-configs`, `pnpm`).
+2. Implement the requested changes.
+
+## Step 3 — Test
+
+Run full workspace checks (no browser verification in patch mode):
+
+1. `pnpm lint` (typecheck + syncpack + oxlint)
+2. `pnpm test` (workspace tests including Storybook a11y)
+3. `pnpm sizecheck` (bundle budgets)
+
+If any check fails, fix the issues and re-run. If after one fix attempt checks still fail:
+- Do NOT retry further.
+- Post a failure comment and STOP (do not push):
+
+    ```markdown
+    ## Patch Iteration — Failed
+
+    **Your request:** "[user feedback verbatim]"
+
+    Changes were applied but tests failed. The commit was NOT pushed.
+
+    ### Failures
+    - [error details]
+
+    You can:
+    - Comment `/patch <refined feedback>` to try again
+    - Run revise mode locally for complex fixes
+    ```
+
+## Step 4 — Commit and Push
+
+Stage, commit, and push. Use commit message `fix: [description based on feedback]` with the `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.
+
+## Step 5 — Report
+
+Post a success comment:
+
+```markdown
+## Patch Iteration
+
+**Your request:** "[user feedback verbatim]"
+
+### Changes
+- `path/to/file.tsx` — [what changed]
+
+CI will validate the push.
+```
+
+## Hard Constraints
+
+- **Bot comments must never contain the literal string `/patch` unescaped.** Use backtick-escaped references when mentioning the command.
+- **This skill runs raw commands (`pnpm lint`, `pnpm test`, `pnpm sizecheck`), NOT the `plantz-adlc-test` skill.**
+- **Always include the user's original request text in comments.**

--- a/.claude/skills/plantz-adlc-plan/SKILL.md
+++ b/.claude/skills/plantz-adlc-plan/SKILL.md
@@ -15,29 +15,27 @@ Draft the technical approach for a feature and output it to a plan file.
 | Input               | Description                                                                                                        |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `run-uuid`          | Run folder identifier                                                                                              |
-| `mode`              | `draft`, `review`, or `revision`                                                                                   |
+| `mode`              | `draft` or `revision`                                                                                              |
 | Feature description | What the user wants built                                                                                          |
 | Escalation path     | `null` except in `revision` mode: path to `escalation-[iteration].md` — explains what the previous plan got wrong. |
-| Existing plan path  | `null` in `draft` mode. In `review` and `revision` modes: path to the current `plan.md`.                           |
+| Existing plan path  | `null` in `draft` mode. In `revision` mode: path to the previous `plan.md`.                                        |
 
 ## Mode
 
 This skill runs in one of three modes, determined by the `mode` input:
 
 - **Draft**: Create a plan from scratch based on the feature description.
-- **Review**: The orchestrator already wrote the user's plan to `plan.md`. Only Subagent B runs — validate format, challenge gaps, and improve. See Subagent Pattern below.
-- **Revision**: Revise the existing plan to address the structural issue described in the escalation file.
+- **Revision**: Revise the existing plan. The revision is driven by either the escalation file or the feature description — whichever is provided.
 
 ## Procedure
 
 1. Read `agent-docs/ARCHITECTURE.md`, `agent-docs/adr/index.md`, `agent-docs/odr/index.md`, and these reference files: `agent-docs/references/domains.md`, `agent-docs/references/msw-tanstack-query.md`, `agent-docs/references/storybook.md`, `agent-docs/references/tailwind-postcss.md`, `agent-docs/references/shadcn.md`, `agent-docs/references/color-mode.md`, `agent-docs/references/bundle-size-budget.md`.
 2. Load the `accessibility`, `shadcn`, `frontend-design`, `workleap-react-best-practices`, `workleap-squide`, and `workleap-web-configs` skills for design guidance.
 3. **Draft mode:** Analyze the feature requirements and determine which packages/modules are affected.
-   **Review mode:** Read the existing plan at the plan path. This plan was written by the user — treat it as the starting point. Proceed directly to step 5 (validate and improve).
-   **Revision mode:** Read the existing plan (at the existing plan path input) and the escalation file (at the escalation path input). Understand what was attempted, what failed structurally, and the proposed alternative. Focus the revision on the structural issue — don't rewrite sections that aren't affected.
+   **Revision mode:** Read the existing plan (at the existing plan path input) and the escalation file (at the escalation path input) if provided. Understand what was attempted, what failed structurally, and the proposed alternative. Focus the revision on the structural issue — don't rewrite sections that aren't affected.
 4. If a new module or storybook needs to be scaffolded, note it in the plan. Do NOT scaffold during planning — that happens during the coding phase.
 5. Draft, revise, or validate and improve the plan following the **plan output format** below.
-6. Write the plan to `./tmp/runs/[run-uuid]/plan.md`.
+6. Write the plan to `.adlc/[run-uuid]/plan.md`.
 
 ## Plan Output Format
 
@@ -110,10 +108,10 @@ Criteria:
 
 ## Subagent Pattern
 
-In **draft mode**, Subagent A drafts the plan from scratch and writes `plan.md`. In **revision mode**, A reads the existing plan and the escalation file, then revises `plan.md` to address the structural issue — keeping sections that aren't affected. In **review mode**, Subagent A is skipped entirely — only B runs.
+In **draft mode**, Subagent A drafts the plan from scratch and writes `plan.md`. In **revision mode**, A reads the existing plan and the escalation file (if provided), then revises `plan.md` to address the structural issue — keeping sections that aren't affected.
 
 In **revision mode**, Subagent B reviews A's revisions — challenges the revised approach, validates that the structural issue from the escalation file is genuinely addressed (not just papered over), and validates acceptance criteria. B should verify that the revised plan doesn't introduce new cross-module dependencies or contradict existing ADRs.
 
-Subagent B reads the plan, challenges it — checking for missing affected packages, unrealistic scope, incorrect patterns, missing stories, or accessibility gaps — and edits `plan.md` directly to improve it. B does not append concerns; it rewrites sections that need improvement. In **review mode**, B also ensures the plan follows the expected output format. If sections are missing, B adds them.
+Subagent B reads the plan, challenges it — checking for missing affected packages, unrealistic scope, incorrect patterns, missing stories, or accessibility gaps — and edits `plan.md` directly to improve it. B does not append concerns; it rewrites sections that need improvement.
 
 **B MUST validate acceptance criteria against the RULES in the plan output format.** If any rule is violated, B fixes the criteria directly.

--- a/.claude/skills/plantz-adlc-pr/SKILL.md
+++ b/.claude/skills/plantz-adlc-pr/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: plantz-adlc-merge
+name: plantz-adlc-pr
 description: |
     Commit, push, open a PR, and monitor CI. Handles CI failures by returning control to the orchestrator.
-    Use when asked to "commit and push", "open a PR", "merge the feature", or as part of the ADLC orchestrator's merge phase.
+    Use when asked to "commit and push", "open a PR", or as part of the ADLC orchestrator's PR phase.
 license: MIT
 ---
 
-# ADLC Merge
+# ADLC PR
 
-Handle committing, pushing, opening a PR, and monitoring CI. Uses a **single subagent** — concurrent git operations would conflict.
+Commit, push, open a PR, and monitor CI.
 
 ## Inputs (provided by orchestrator)
 
@@ -17,31 +17,51 @@ Handle committing, pushing, opening a PR, and monitoring CI. Uses a **single sub
 | `run-uuid`   | Run folder identifier                                                                                                                                                                                                                                                                                |
 | Branch name  | The branch created in the orchestrator step 2                                                                                                                                                                                                                                                        |
 | Commit type  | Conventional commit prefix: `feat`, `fix`, `chore`, `docs`, or `refactor`                                                                                                                                                                                                                            |
-| Plan path    | `./tmp/runs/[run-uuid]/plan.md` — needed for acceptance criteria                                                                                                                                                                                                                                     |
+| Plan path    | `.adlc/[run-uuid]/plan.md` — needed for acceptance criteria                                                                                                                                                                                                                                     |
 | Iteration    | The final iteration number. To find `## Verification results`, scan backwards from `changes-[iteration].md` through earlier `changes-*.md` files until one contains the section. During CI fix cycles the latest changes file may lack verification results because only the test skill writes them. |
-| CI iteration | Current CI fix iteration number (0-3), provided by orchestrator. Used to name `ci-issues-[iteration].md`. Defaults to `0` on first merge.                                                                                                                                                            |
+| CI iteration    | Current CI fix iteration number (0-3), provided by orchestrator. Used to name `ci-issues-[iteration].md`. Defaults to `0` on first PR creation.                                                                                                                                                            |
+| `--revision` | Optional. When set, the PR already exists — edit the body instead of creating a new PR. Append a `## Revision [N]` section and update the footer with the new run UUID.                                                                                                                              |
 
 ## Step 1 — Commit
 
-If the working tree is clean (`git status --short` produces no output), skip Step 1 and proceed to Step 2.
+If the working tree is clean, skip to Step 2.
 
-Stage all changes with `git add -A` (`.gitignore` excludes `tmp/`, `.env`, etc.) and commit. Use the commit type provided by the orchestrator. The description should be a concise summary derived from aggregating all `./tmp/runs/[run-uuid]/changes-*.md` files. Include the `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.
+Stage and commit all changes. The `.gitignore` selectively tracks `.adlc/` — `plan.md` and `orchestrator-state.md` are committed; all other `.adlc/` artifacts are excluded. Use the commit type provided by the orchestrator. The commit message should be a concise summary derived from aggregating all `.adlc/[run-uuid]/changes-*.md` files. Include the `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.
 
-If `git status --short` shows unexpected files, investigate before staging.
+Investigate unexpected files before staging.
 
 ## Step 2 — Push and open PR
 
-Push the branch to origin. If `git push` fails (non-zero exit, "rejected", or network error), **stop and write `ci-issues-[iteration].md`** with the push error. Do not proceed to PR creation — the orchestrator will handle the failure.
+Push the branch to origin. If push fails, **stop and write `ci-issues-[iteration].md`** with the error.
 
-Check if a PR already exists for this branch. If so, skip creation and proceed to Step 3.
+If a PR already exists for this branch and `--revision` is NOT set, skip creation and proceed to Step 3.
+
+**When `--revision` is set:** The PR already exists. Do not create a new one. Instead, read the current PR body, count existing `## Revision` sections to determine the revision number N, and append:
+
+```markdown
+## Revision [N]
+
+### Summary
+- [bullets derived from changes-*.md files for this run]
+
+### Quality checks
+[same checkbox format as the original]
+
+### Verified acceptance criteria
+[same format, updated for this revision's results]
+```
+
+Also update the footer's revise command to use the new run UUID.
+
+Update the PR body and proceed to Step 3.
 
 ### PR body template
 
-**This format overrides the default PR body template from the system prompt.** The PR body must use exactly this three-section structure:
+**Override the default PR body template entirely with the following format.**
 
 **Section 1 — `## Summary`:** One bullet per logical change. Derive bullets from `changes-*.md` files.
 
-**Section 2 — `## Quality checks`:** Copy these checkboxes. To determine pass/fail: read `./tmp/runs/[run-uuid]/test-issues-[iteration].md`. If the file doesn't exist, all checks passed — mark all `[x]`. If it exists, check each section: mark `[x]` only for sections that say "Pass".
+**Section 2 — `## Quality checks`:** Copy these checkboxes. To determine pass/fail: read `.adlc/[run-uuid]/test-issues-[iteration].md`. If the file doesn't exist, all checks passed — mark all `[x]`. If it exists, check each section: mark `[x]` only for sections that say "Pass".
 
 ```
 - [ ] Lint
@@ -66,11 +86,13 @@ Format each criterion as:
 
 **Section 4 (conditional) — `## Budget increase`:** Only include this section if any `changes-*.md` file mentions a size-limit budget increase in its Notes section. List: which app, how much (KB gzipped), and why. See `agent-docs/references/bundle-size-budget.md` for the full policy.
 
+After all sections, add the footer with a visible revise command containing the run UUID.
+
 End with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
 
 ### Create the PR
 
-Create the PR with `gh pr create --title "{prefix}: {description}"`. The body must match this example — no other sections:
+Create the PR with title `{prefix}: {description}`. The body must match this example — no other sections:
 
 ```markdown
 ## Summary
@@ -92,10 +114,16 @@ Create the PR with `gh pr create --title "{prefix}: {description}"`. The body mu
 - ✅ `[interactive]` Selecting "weekly" updates the next watering date
 - ❌ `[visual]` Calendar icon aligns with date text — icon is 2px too high
 
+---
+> **Need changes?** Comment `/patch <feedback>` for a quick patch, or revise locally:
+> ```
+> /plantz-adlc-orchestrator --revise "your feedback" --previous-run-uuid [run-uuid]
+> ```
+
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
-If `gh pr create` fails, retry once. If it fails again, **stop and write `ci-issues-[iteration].md`** with the error. Do not proceed to CI monitoring without a PR.
+If PR creation fails, retry once. If it fails again, **stop and write `ci-issues-[iteration].md`** with the error. Do not proceed to CI monitoring without a PR.
 
 ## Step 3 — Monitor PR
 
@@ -109,12 +137,12 @@ Not all CI workflows report results the same way. Some report via check run stat
 | `Code Review` (code-review.yml)  | Check run status | Monitored                                            |
 | `Smoke Tests` (smoke-tests.yml)  | PR comment       | Monitored — scan bot comments for failure indicators |
 | `Lighthouse CI` (lighthouse.yml) | Check run status | Monitored                                            |
-| `Chromatic` (chromatic.yml)      | Check run status | Excluded — label-gated, runs after merge skill exits |
+| `Chromatic` (chromatic.yml)      | Check run status | Excluded — label-gated, runs after PR skill exits |
 | `Claude` (claude.yml)            | —                | Excluded — triggered by `@claude` mentions, not CI   |
 
 **Monitored workflows:** `CI`, `Code Review`, `Smoke Tests`, `Lighthouse CI`. These are tracked in the CI Validation comment.
 
-**Excluded workflows:** `Chromatic` (label-gated, runs after merge skill exits), `Claude` (triggered by mentions, not CI).
+**Excluded workflows:** `Chromatic` (label-gated, runs after PR skill exits), `Claude` (triggered by mentions, not CI).
 
 ### Polling loop
 
@@ -128,11 +156,11 @@ Query workflow runs for the branch. Filter out `Chromatic` and `Claude` runs by 
 
 Scan PR comments **only from known bot authors** (`claude[bot]`, `github-actions[bot]`) for failure indicators: lines containing "❌", or lines where "failed", "FAIL", or "error:" appear in a context indicating an actual failure (not a zero-count like "0 failed"). When in doubt, read the full comment body. **Ignore user comments** — those are code review feedback, not CI results.
 
-**Stabilization check:** After all monitored workflows complete, run **one additional poll cycle** (60 seconds) before declaring "all green." This mitigates the race condition where a workflow completes successfully but its bot comment reporting failures hasn't posted yet (e.g., Smoke Tests always exits 0 but posts failure details as a PR comment).
+**Stabilization check:** After all monitored workflows complete, run **one additional poll cycle** (60 seconds) before declaring "all green."
 
 ### Decision flow
 
-1. **CI failure (workflow or bot comment):** If any monitored workflow has `conclusion: "failure"` **or** any bot PR comment reports failures, read the failure logs. Write the errors to `./tmp/runs/[run-uuid]/ci-issues-[iteration].md` using this format, then **stop — do not attempt further actions**. The orchestrator handles the fix cycle.
+1. **CI failure (workflow or bot comment):** If any monitored workflow has `conclusion: "failure"` **or** any bot PR comment reports failures, read the failure logs. Write the errors to `.adlc/[run-uuid]/ci-issues-[iteration].md` using this format, then **stop**.
 
     ```markdown
     # CI Issues — Iteration [N]
@@ -146,17 +174,13 @@ Scan PR comments **only from known bot authors** (`claude[bot]`, `github-actions
     - [error output]
     ```
 
-2. **All green — add Chromatic label and report success:** When all monitored workflows have completed successfully **and** no bot PR comments report failures **and** the stabilization check has passed, add the `run chromatic` label and **stop**. Do **not** wait for Chromatic to complete — visual regressions require human review. Report success after adding the label.
+2. **All green — add Chromatic label and report success:** When all monitored workflows have completed successfully **and** no bot PR comments report failures **and** the stabilization check has passed, add the `run chromatic` label and **stop**.
 
-3. **Not completed:** If the polling loop reaches 30 minutes and some monitored workflows have not completed, post the CI Validation comment showing which workflows are still running, then **stop**. Do not write `ci-issues-[iteration].md`. Do not add the `run chromatic` label. The remaining workflows will resolve on their own via GitHub's checks.
+3. **Not completed:** If the polling loop reaches 30 minutes and some monitored workflows have not completed, post the CI Validation comment showing which workflows are still running, then **stop**. Do not write `ci-issues-[iteration].md`. Do not add the `run chromatic` label.
 
 ### CI Validation comment
 
-**Always** post a sticky PR comment before exiting, regardless of outcome. This is a snapshot of what the agent observed at the time it stopped monitoring.
-
-**Sticky behavior:** Before posting, search for an existing comment starting with `## CI Validation` on the PR. If found, update it in place. If not found, create a new one. This avoids clutter across CI iterations.
-
-**Comment format — all workflows completed successfully:**
+Post or update a sticky `## CI Validation` PR comment before exiting. Formats:
 
 ```markdown
 ## CI Validation
@@ -169,8 +193,6 @@ All monitored workflows completed successfully.
 - [x] Lighthouse CI
 ```
 
-**Comment format — one or more workflows failed:**
-
 ```markdown
 ## CI Validation
 
@@ -179,8 +201,6 @@ All monitored workflows completed successfully.
 - [x] Code Review
 - [x] Lighthouse CI
 ```
-
-**Comment format — agent timed out before all workflows finished:**
 
 ```markdown
 ## CI Validation
@@ -193,14 +213,10 @@ All monitored workflows completed successfully.
 - [ ] Lighthouse CI — still running
 ```
 
-**Checklist entries:** One line per monitored workflow (`CI`, `Code Review`, `Smoke Tests`, `Lighthouse CI`). Use `- [x]` for completed+success, `- [ ] Name — failed` for completed+failure, `- [ ] Name — still running` for workflows that did not complete.
-
-**Post the comment before executing the terminal action** (adding the `run chromatic` label on success, or writing `ci-issues-[iteration].md` on failure/timeout).
-
 ## Hard Constraints
 
-- **The PR body MUST have exactly three sections: `## Summary`, `## Quality checks`, `## Verified acceptance criteria`.** The only allowed additional section is `## Budget increase` (conditional — only when a budget was increased).
+- **The PR body MUST have three mandatory sections: `## Summary`, `## Quality checks`, `## Verified acceptance criteria`.** The only allowed additional sections are `## Budget increase` (conditional — only when a budget was increased) and `## Revision [N]` (added by revise runs via `--revision`).
 
 ## Subagent Pattern
 
-This skill runs as a **single subagent**. Do not spawn two — git push/commit conflicts are not recoverable. This subagent cannot spawn further subagents. When CI failures require code changes, the merge subagent writes the issues to a file and stops. The orchestrator handles subagent spawning for fixes.
+This skill runs as a **single subagent**. When CI failures require code changes, write the issues to a file and stop.

--- a/.claude/skills/plantz-adlc-test/SKILL.md
+++ b/.claude/skills/plantz-adlc-test/SKILL.md
@@ -16,12 +16,12 @@ The single validation gate for all code quality. Runs static checks (lint, modul
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `run-uuid`           | Run folder identifier                                                                                                                       |
 | `iteration`          | Current iteration number                                                                                                                    |
-| Plan path            | `./tmp/runs/[run-uuid]/plan.md` — needed for acceptance criteria                                                                            |
+| Plan path            | `.adlc/[run-uuid]/plan.md` — needed for acceptance criteria                                                                            |
 | Previous issues path | `null` on iteration 1. On iteration > 1: path to `test-issues-[iteration-1].md`. May not exist if the previous iteration passed all checks. |
 
 ## Procedure
 
-1. Read all `./tmp/runs/[run-uuid]/changes-*.md` files (1 through current iteration) to build the cumulative set of affected files. This ensures accessibility checks cover the full feature scope, not just the latest fix.
+1. Read all `.adlc/[run-uuid]/changes-*.md` files (1 through current iteration) to build the cumulative set of affected files. This ensures accessibility checks cover the full feature scope, not just the latest fix.
 2. Read these reference files for technology rules and quality standards: `agent-docs/references/msw-tanstack-query.md`, `agent-docs/references/storybook.md`, `agent-docs/references/tailwind-postcss.md`, `agent-docs/references/shadcn.md`, `agent-docs/references/color-mode.md`, `agent-docs/references/bundle-size-budget.md`.
 3. Run `pnpm lint` from the workspace root. This includes typecheck and syncpack. Record any errors.
 4. Run `pnpm sizecheck` to check bundle budgets. If it fails, record the full size-limit output in the issues file under `## Bundle size`. Do not attempt to fix or increase budgets — that is the code skill's responsibility.
@@ -30,7 +30,7 @@ The single validation gate for all code quality. Runs static checks (lint, modul
 7. **Browser verification**: Read `plan.md` and extract all `[visual]` and `[interactive]` acceptance criteria. If any exist, follow the browser verification procedure (below) to verify them. Record pass/fail for each criterion.
 8. **Workspace tests**: Run `pnpm test` from the workspace root. This runs all workspace test tasks (including Storybook a11y). See the workspace tests procedure (below). This step runs **unconditionally** — it is not gated by `[visual]`/`[interactive]` criteria.
 9. **Regression check** (iteration > 1 only): If a previous issues path was provided and that file exists, compare the current iteration's issues with the previous iteration's issues. Any issue in the current run that was NOT present in the previous iteration is a regression introduced by the fix cycle. Prefix these with `⚠️ REGRESSION:` in the issues file so the code skill knows to revert the offending change rather than pile on more fixes. If the previous issues file doesn't exist (previous iteration passed), treat all current issues as regressions.
-10. **Always** write the final `## Verification results` section into the latest `changes-[iteration].md` file (add it after `## Notes`), regardless of whether checks passed or failed. The merge skill needs this section to populate the PR. End the section with the completion marker `<!-- test-complete -->` as the very last line — this is how the orchestrator distinguishes "all checks passed" from "subagent crashed." Use this format:
+10. **Always** write the final `## Verification results` section into the latest `changes-[iteration].md` file (add it after `## Notes`), regardless of whether checks passed or failed. The PR skill needs this section to populate the PR. End the section with the completion marker `<!-- test-complete -->` as the very last line — this is how the orchestrator distinguishes "all checks passed" from "subagent crashed." Use this format:
 
     ```markdown
     ## Verification results
@@ -90,7 +90,7 @@ Run all workspace tests as a gate check. This includes Storybook a11y tests (axe
 ## Output
 
 - If **all checks pass** (static, browser, and workspace tests): do NOT create an issues file. The orchestrator uses the `<!-- test-complete -->` marker in `changes-[iteration].md` (written in step 10) to confirm the test ran to completion.
-- If **any check fails**: write the issues to `./tmp/runs/[run-uuid]/test-issues-[iteration].md` with this format:
+- If **any check fails**: write the issues to `.adlc/[run-uuid]/test-issues-[iteration].md` with this format:
 
 ```markdown
 # Test Issues — Iteration [N]

--- a/.claude/skills/plantz-smoke-tests/SKILL.md
+++ b/.claude/skills/plantz-smoke-tests/SKILL.md
@@ -16,7 +16,7 @@ This skill requires `agent-browser` CLI for browser verification (navigating to 
 
 ## Run Folder
 
-Generate a UUID and create `./tmp/smoke-tests/[run-uuid]/`. All screenshots and artifacts go in this folder.
+Generate a UUID and create `.smoke-tests/[run-uuid]/`. All screenshots and artifacts go in this folder.
 
 ## Target
 
@@ -50,7 +50,7 @@ The app redirects unauthenticated users to `/login`. You must log in before veri
 
 1. Take a page snapshot and confirm the authenticated layout loaded (header, navigation, content area — not the login form).
 2. Check the browser console for errors. Warnings are acceptable — errors are not.
-3. Take a screenshot and save it to `./tmp/smoke-tests/[run-uuid]/{app-name}.png`.
+3. Take a screenshot and save it to `.smoke-tests/[run-uuid]/{app-name}.png`.
 
 ### Step 5 — Stop the dev server
 
@@ -82,7 +82,7 @@ taskkill //PID <PID> //T //F
 
 ## Cleanup
 
-- **On success:** delete the run folder: `rm -rf ./tmp/smoke-tests/[run-uuid]`.
+- **On success:** delete the run folder: `rm -rf .smoke-tests/[run-uuid]`.
 - **On failure:** never delete the run folder. Leave artifacts for diagnosis.
 
 ## Summary

--- a/.github/workflows/adlc-patch.yml
+++ b/.github/workflows/adlc-patch.yml
@@ -1,0 +1,103 @@
+name: Iterate (Patch)
+
+on:
+    issue_comment:
+        types: [created]
+
+concurrency:
+    group: pr-iterate-${{ github.event.issue.number }}
+    cancel-in-progress: true
+
+jobs:
+    iterate-patch:
+        # Only trigger on PR comments containing /patch from repo collaborators
+        if: |
+            github.event.issue.pull_request &&
+            contains(github.event.comment.body, '/patch') &&
+            (
+                github.event.comment.author_association == 'OWNER' ||
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'COLLABORATOR'
+            )
+
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        permissions:
+            contents: write
+            pull-requests: write
+            issues: write
+            id-token: write
+            actions: read
+
+        steps:
+            - name: Get PR details
+              id: pr
+              run: |
+                  PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+                  echo "head_ref=$(echo "$PR_DATA" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
+                  echo "head_sha=$(echo "$PR_DATA" | jq -r .head.sha)" >> "$GITHUB_OUTPUT"
+              env:
+                  GH_TOKEN: ${{ github.token }}
+
+            - name: Checkout PR branch
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ steps.pr.outputs.head_ref }}
+                  fetch-depth: 0
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: false
+
+            - name: Install Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ">=24.0.0"
+                  check-latest: true
+                  cache: pnpm
+                  cache-dependency-path: pnpm-lock.yaml
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Restore Turborepo cache
+              id: cache-turborepo-restore
+              uses: actions/cache/restore@v5
+              with:
+                  key: ${{ runner.os }}-turbo-iterate-${{ github.sha }}
+                  restore-keys: |
+                      ${{ runner.os }}-turbo-iterate-
+                      ${{ runner.os }}-turbo-
+                  path: .turbo
+
+            - name: Run Claude (patch iterate)
+              uses: anthropics/claude-code-action@v1
+              with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  prompt: |
+                      You are running in PATCH ITERATE mode on PR #${{ github.event.issue.number }}.
+
+                      Load and follow the `plantz-adlc-patch` skill.
+
+                      The user's feedback from the PR comment:
+                      ${{ github.event.comment.body }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+
+            - name: Save Turborepo cache
+              id: cache-turborepo-save
+              if: always() && steps.cache-turborepo-restore.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v5
+              with:
+                  key: ${{ steps.cache-turborepo-restore.outputs.cache-primary-key }}
+                  path: .turbo
+
+            - name: Post failure comment
+              if: failure()
+              run: |
+                  gh pr comment ${{ github.event.issue.number }} --body "## Patch Iteration — Workflow Failed
+
+                  The iterate workflow failed unexpectedly. Check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+              env:
+                  GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     claude:
         if: |
-            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '/patch')) ||
             (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
             (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
             (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,15 @@ chromatic-diagnostics.json
 .rslib
 .netlify
 .claude/worktrees
-tmp
 .env
 *.env.local
+.smoke-tests
+
+# ADLC run artifacts — track only files needed for revise mode
+# IMPORTANT: .adlc/*/* must target FILES inside UUID dirs (not the dirs themselves)
+# so git still traverses into them and negation patterns work.
+.adlc/*/*
+!.adlc/*/plan.md
+!.adlc/*/orchestrator-state.md
+
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ Four pillars make this repo fully agent-driven. Each section links to the implem
 
 ### 1. ADLC skills — end-to-end feature development
 
-Six skills that form a complete Agent Development Life Cycle (ADLC). The orchestrator (`/plantz-adlc-orchestrator`) is the sole entry point for feature development — it spawns subagents for each phase and coordinates them through file-based handoffs in `./tmp/runs/[uuid]/`.
+Seven skills that form a complete Agent Development Life Cycle (ADLC). Two flows:
+
+**New feature** — run the orchestrator locally with a feature request. It creates a branch, spawns subagents for each phase (plan, code, test, document), opens a PR, and monitors CI.
+
+```
+/plantz-adlc-orchestrator Add a vacation planner page with date picker and delegation support
+```
+
+**Revise a feature** — on the PR branch, run the orchestrator with `--revise` to apply feedback through the full ADLC pipeline (plan revision, code, test, document, push).
+
+```
+/plantz-adlc-orchestrator --revise "restructure the data layer to use TanStack DB" --previous-run-uuid abc123
+```
+
+The `--previous-run-uuid` is shown in the PR description footer. For lightweight fixes, comment `/patch <feedback>` directly on the PR instead — a CI workflow applies the patch, runs tests, and pushes.
+
+All inter-step coordination goes through files in `.adlc/[uuid]/`.
 
 ```mermaid
 flowchart TD
@@ -59,10 +75,10 @@ flowchart TD
         Test -- "issues found" --> Code
         Test -- "all passed" -->
         Document["<b>Document</b><br/>A audits · B reviews"] -->
-        Merge["<b>Merge</b><br/>commit, PR, CI"]
+        PR["<b>PR</b><br/>commit, push, CI"]
     end
 
-    Merge --> Done([PR ready])
+    PR --> Done([PR ready])
 
     style Start fill:#4ade80,stroke:#16a34a,color:#000
     style Done fill:#4ade80,stroke:#16a34a,color:#000
@@ -71,18 +87,19 @@ flowchart TD
 
 | Skill                      | What it does                                                                                                   |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `plantz-adlc-orchestrator` | Entry point. Generates a run UUID, creates a branch, and runs steps 1-9 sequentially                           |
+| `plantz-adlc-orchestrator` | Entry point. Generates a run UUID, creates a branch, and runs steps 1-8 sequentially                           |
 | `plantz-adlc-plan`         | Drafts a structured technical plan with tagged acceptance criteria (`[static]`, `[visual]`, `[interactive]`)   |
 | `plantz-adlc-code`         | Implements the plan or fixes issues. Uses Chrome DevTools MCP for visual feedback while coding                 |
 | `plantz-adlc-test`         | Single validation gate — static checks (lint, modules, accessibility) and browser verification of all criteria |
 | `plantz-adlc-document`     | Audits agent-docs and CLAUDE.md for drift, creates ADRs/ODRs if new decisions were made                        |
-| `plantz-adlc-merge`        | Commits, pushes, opens a PR with strict template, monitors CI. Returns control on failures                     |
+| `plantz-adlc-pr`           | Commits, pushes, opens a PR, monitors CI. Returns control on failures                                          |
+| `plantz-adlc-patch`        | Lightweight PR iteration — applies scoped fixes from `/patch` comments in CI                                   |
 
 Key design decisions:
 
 - **Shared references**: Tech-stack rules (Tailwind, Storybook, shadcn, MSW, color mode) live in `agent-docs/references/` as a single source of truth. Each ADLC skill explicitly lists which references it reads — no duplication, no drift.
 - **Subagent protocol**: Every multi-agent step uses a drafter/reviewer pair (A drafts, B reviews and improves). The orchestrator spawns both — subagents never spawn further subagents.
-- **File-based coordination**: All inter-step communication goes through files in `./tmp/runs/[uuid]/`. This makes handoffs explicit and debuggable (see "Run folder artifacts" below).
+- **File-based coordination**: All inter-step communication goes through files in `.adlc/[uuid]/`. This makes handoffs explicit and debuggable (see "Run folder artifacts" below).
 - **Test as the single gate**: The test skill owns all verification — both static (lint, modules, accessibility) and visual/interactive (browser screenshots via Chrome DevTools MCP). The code skill writes code; the test skill validates it.
 - **Acceptance criteria flow**: Plan tags each criterion. Test verifies them and writes results to `changes-*.md`. Merge reads results and populates the PR with pass/fail status. See [Acceptance criteria flow](#acceptance-criteria-flow) below.
 
@@ -122,10 +139,10 @@ A maximum of one plan revision is allowed per run — the system fails fast rath
 
 #### Run folder artifacts
 
-Every ADLC run produces files in `./tmp/runs/[uuid]/` that flow between subagents:
+Every ADLC run produces files in `.adlc/[uuid]/` that flow between subagents:
 
 ```
-./tmp/runs/[uuid]/
+.adlc/[uuid]/
   ├─ orchestrator-state.md    # Orchestrator writes after each step (recovery on context compaction)
   ├─ plan.md                  # Plan skill writes → Code, Test, Merge read
   ├─ changes-1.md             # Code writes → Test appends verification results → Merge reads for PR
@@ -135,8 +152,6 @@ Every ADLC run produces files in `./tmp/runs/[uuid]/` that flow between subagent
   ├─ ci-issues-1.md           # Merge writes (only if CI fails) → Code reads for fix
   └─ failure-summary.md       # Orchestrator writes on unrecoverable failure
 ```
-
-The folder is deleted on successful completion and preserved on failure for post-mortem.
 
 **Files:** [`.claude/skills/plantz-adlc-*/`](.claude/skills/)
 
@@ -193,7 +208,7 @@ pnpm test           # Runs all workspace tests (including Storybook a11y) via Tu
 
 #### CI/CD
 
-Seven GitHub Actions workflows, four of which involve Claude Code:
+Eight GitHub Actions workflows, five of which involve Claude Code:
 
 | Workflow          | Trigger                         | Purpose                                                                               |
 | ----------------- | ------------------------------- | ------------------------------------------------------------------------------------- |
@@ -203,6 +218,7 @@ Seven GitHub Actions workflows, four of which involve Claude Code:
 | `claude.yml`      | `@claude` mention in issues/PRs | Claude Code agent responds to issues and PR comments                                  |
 | `code-review.yml` | PRs opened/updated              | Automated code review by Claude (read-only tools)                                     |
 | `smoke-tests.yml` | PRs to main                     | Smoke-tests all apps via Claude (scoped Bash, artifact upload on failure)             |
+| `adlc-patch.yml`  | `/patch` in PR comments         | Patch iteration — lightweight fixes on existing PRs via Claude                        |
 
 **Files:** [`.github/workflows/`](.github/workflows/), [`.github/prompts/`](.github/prompts/)
 

--- a/agent-docs/references/ci-cd.md
+++ b/agent-docs/references/ci-cd.md
@@ -1,6 +1,6 @@
 # CI/CD Reference
 
-Seven GitHub Actions workflows in `.github/workflows/`:
+Eight GitHub Actions workflows in `.github/workflows/`:
 
 | File                   | Purpose                                                                                  |
 | ---------------------- | ---------------------------------------------------------------------------------------- |
@@ -11,6 +11,7 @@ Seven GitHub Actions workflows in `.github/workflows/`:
 | `code-review.yml`      | Automated PR code review via Claude                                                      |
 | `audit-agent-docs.yml` | Weekly agent-docs freshness audit                                                        |
 | `smoke-tests.yml`      | Smoke-test the host app on PRs via Claude                                                |
+| `adlc-patch.yml`       | Patch iteration on PRs via `/patch` comments                                             |
 
 Read the YAML files directly for triggers, steps, and concurrency rules.
 
@@ -64,9 +65,19 @@ These deploys are independent of the GitHub Actions workflows listed above — N
 
 ## Turbo cache strategy
 
-Five workflows (ci, lighthouse, chromatic, claude, smoke-tests) share a Turbo cache pattern with restore-key prefixes (`${{ runner.os }}-turbo-`) that allow cross-workflow cache hits. `code-review.yml` and `audit-agent-docs.yml` do not use Turbo cache.
+Six workflows (ci, lighthouse, chromatic, claude, smoke-tests, adlc-patch) share a Turbo cache pattern with restore-key prefixes (`${{ runner.os }}-turbo-`) that allow cross-workflow cache hits. `code-review.yml` and `audit-agent-docs.yml` do not use Turbo cache.
 
 When adding a new workflow that runs Turbo tasks, follow the existing pattern: restore before tasks, save on cache miss (`cache-hit != 'true'`), use prefix fallback keys.
+
+## Iterate (Patch mode)
+
+`adlc-patch.yml` runs when a user comments `/patch <feedback>` on a PR. It applies lightweight, scoped fixes without running the full ADLC pipeline.
+
+**Trigger:** `issue_comment` (created) containing `/patch`, filtered to PR comments from OWNER/MEMBER/COLLABORATOR.
+
+**Concurrency:** `pr-iterate-${{ github.event.issue.number }}` with `cancel-in-progress: true`. Multiple simultaneous comments — only the latest executes.
+
+**Revise mode:** For changes exceeding patch scope, the agent posts a ready-to-paste local command: `/plantz-adlc-orchestrator --revise "<feedback>" --previous-run-uuid <uuid>`. This runs the full ADLC on the existing PR branch with all quality gates.
 
 ---
 


### PR DESCRIPTION
- Add /patch workflow (adlc-patch.yml) for lightweight PR iteration via CI
- Add revise mode to orchestrator (--revise, --previous-run-uuid) for full ADLC on existing branches
- Migrate run artifacts from ./tmp/runs/ to .adlc/ with selective git tracking (plan.md, orchestrator-state.md)
- Rename plantz-adlc-merge to plantz-adlc-pr
- Add visible revise command in PR footer with run UUID
- Update claude.yml to exclude /patch comments
- Migrate smoke-tests to .smoke-tests/
- Lint hook now blocks on errors only (warnings pass through)
- Remove plan review mode (inline plans)
- Remove Step 9 cleanup (artifacts persist for revise)
- Trim orchestrator and PR skill instructions (remove fluff, git commands, justifications)
- Update reference file lists in code and patch skills
- Update README with two ADLC flows (new feature + revise) and /patch documentation